### PR TITLE
Fix argument order on evaluateCompletion()

### DIFF
--- a/completion-plugin/src/main/kotlin/org/jb/cce/actions/CompletionEvaluationStarter.kt
+++ b/completion-plugin/src/main/kotlin/org/jb/cce/actions/CompletionEvaluationStarter.kt
@@ -31,6 +31,6 @@ class CompletionEvaluationStarter : ApplicationStarter {
         val files  = config.listOfFiles.map { fileSystem.findFileByIoFile(File(it))!! }
 
         CompletionEvaluator(true).evaluateCompletion(project, files, config.language, config.strategy,
-                config.completionTypes, config.outputDir, config.saveLogs, config.interpretActions, config.logsTrainingPercentage)
+                config.completionTypes, config.outputDir, config.interpretActions, config.saveLogs, config.logsTrainingPercentage)
     }
 }


### PR DESCRIPTION
Change argument order on evaluateCompletion() to match function signature (report generation in headless mode fix).
https://github.com/bibaev/code-completion-evaluation/blob/1dd36dc39dbe3dddbf738a03e02e0f5b9edff7d4/completion-plugin/src/main/kotlin/org/jb/cce/CompletionEvaluator.kt#L39-L40